### PR TITLE
Fix regex, remove awk and xdg-mime dependency

### DIFF
--- a/bibsearch
+++ b/bibsearch
@@ -1,12 +1,12 @@
 #!/bin/sh
 
 CheckArg () {
-    doi_regex='[https://doi.org/]?10\.[0-9]{4}[0-9.]*/[^[:space:]]*'
+    doi_regex='(https://doi.org/)?10\.[0-9]{4}[0-9.]*/[^[:space:]]*'
     if echo "$1" | grep -E -q -o "$doi_regex"; then
 	doi="$1"
-    elif [ "$(xdg-mime query filetype "$1")" = "application/pdf" ]; then
+    elif [ "$(dd if="$1" count=4 bs=1 status=none)" = "%PDF" ]; then
 	doi="$(pdfinfo "$1" | grep -E -q -o "$doi_regex")"
-	[ -z "$doi" ] && info="$(pdfinfo "$1" | grep -io "Title:.*" | awk -F ':          ' '{print $2}')"
+	[ -z "$doi" ] && { info="$(pdfinfo "$1" | grep "^Title")"; info="${info#Title: *}"; }
 	[ -z "$info" ] && info="$(pdftotext "$1" 2>/dev/null - | head -n 4)"
 	[ -z "$info" ] && echo "Cannot identify doi or title from pdf file." && exit 1
     else
@@ -54,7 +54,7 @@ bibnl () {
 BibGen () {
     if [ -n "$doi" ]; then
 	bibtex="$(curl -s "http://api.crossref.org/works/$doi/transform/application/x-bibtex")"
-	if echo "$bibtex" | grep -E "^@[a-z]*{.*," && [ -z "$(awk -v RS='@' "/$info/" $BIB)" ]; then
+	if echo "$bibtex" | grep -E "^@[a-z]*{.*," && grep -F "$info" $BIB; then
 		printf '%s\n' "$bibtex" >> "$BIB" && echo "Reference added to $BIB"
 	fi
     fi


### PR DESCRIPTION
The [] operator does not group characters, but it matches any character
in the group, i.e. [https://doi.org/] would match just a single /.  To
actually match the optional substring you need parentheses (only works
with extended regexp).

xdg-mime is unnecessary to check for a PDF file.  The PDF standard
demands that the first line of a PDF file always has the form

    %PDF-1.4

where 1.4 is version and can vary.  So it's easier to just grab the
first four bytes of a file and check whether it's "%PDF".

The awk dependency is unnecessary as well because stripping "Title:" can
be done with pure shell substitution.  To look up whether the DOI
already exists in the $BIB file, awk is actually harmful because the DOI
always contains a slash which breaks regexp.  Instead it's probably
better to just search for the fixed string of the DOI in the file.
That's more robust and since DOIs are unique you should not have two
different bib entries with the same DOI.